### PR TITLE
Allow testing build manually on `main` branch

### DIFF
--- a/.github/workflows/pelican.yml
+++ b/.github/workflows/pelican.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
-  workflow_call:
+    inputs:
+      deploy:
+        required: false
+        default: true
+        description: "Whether to deploy the site. If true then build the site and deploy it. If false then just test that the site build's successfully but don't deploy anything."
+        type: boolean
 jobs:
   Deploy:
     uses: seanh/pelican/.github/workflows/github_pages.yml@pelican_decouple_build_workflow-single-file
@@ -16,4 +21,4 @@ jobs:
       settings: "publishconf.py"
       requirements: "pelican[markdown] typogrify"
       theme: "https://github.com/seanh/sidecar.git"
-      deploy: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
+      deploy: ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy == true) || (github.event_name == 'push' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch) }}


### PR DESCRIPTION
Allow testing build manually on main branch
    
Allow running the `pelican.yml` workflow manually on the main branch and telling it to test the build only, not deploy.

