### PR TITLE
Run CI on pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Test Pelican build
 on:
-  push:
+  pull_request:
   workflow_dispatch:
 jobs:
   deploy:


### PR DESCRIPTION
Don't run CI on `main` after merging a PR.
